### PR TITLE
Fixed close method to proper exit powershell console in Windows

### DIFF
--- a/src/main/java/com/github/tuupertunut/powershelllibjava/PowerShell.java
+++ b/src/main/java/com/github/tuupertunut/powershelllibjava/PowerShell.java
@@ -155,6 +155,7 @@ public class PowerShell implements Closeable {
     public void close() {
         closed = true;
         if (commandInput != null) {
+            commandInput.println("exit");
             commandInput.close();
         }
         if (executor != null) {


### PR DESCRIPTION
The close method didn't work in Windows. It just hangs and the powershell.exe and cmd.exe processes stay forever even if java process is killed. 
Just calling "exit" command on powershell exits powershell and then the Process is correctly destroyed.